### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -62,7 +62,12 @@ function isApiRoute(url) {
 
 // Function to check if a request is for a card image from Scryfall or similar
 function isCardImage(url) {
-  return url.includes('scryfall.com') || url.includes('gatherer.wizards.com');
+  try {
+    const parsedUrl = new URL(url);
+    return parsedUrl.host === 'scryfall.com' || parsedUrl.host === 'gatherer.wizards.com';
+  } catch (e) {
+    return false;
+  }
 }
 
 // Fetch event - handle network requests


### PR DESCRIPTION
Potential fix for [https://github.com/Hackerax1/MagicPods/security/code-scanning/5](https://github.com/Hackerax1/MagicPods/security/code-scanning/5)

To fix the problem, we need to parse the URL and check the host component explicitly rather than using a substring check. This ensures that only URLs with the exact specified hosts are accepted.

- Parse the URL using the `URL` constructor to extract the host component.
- Check if the host matches the allowed hosts ('scryfall.com' or 'gatherer.wizards.com').


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
